### PR TITLE
Add Web-UI Flasher Example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,11 +5,13 @@
 /tmp
 /out-tsc
 /example/bundle.js
+/example/bundle.js
 # Only exists if Bazel was run
 /bazel-out
 
 # dependencies
 /node_modules
+package-lock.json
 
 # profiling files
 chrome-profiler-events*.json

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 /tmp
 /out-tsc
 /example/bundle.js
-/example/bundle.js
 # Only exists if Bazel was run
 /bazel-out
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /dist
 /tmp
 /out-tsc
+/example/bundle.js
 # Only exists if Bazel was run
 /bazel-out
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 # BOSSA Web
 
-This library provides the core functionality of BOSSA in a JavaScript library that can be 
-used in a web browser that support the Web-Serial API.
-
+This library provides the core functionality of [BOSSA](https://github.com/shumatech/BOSSA) in a JavaScript library that can be used in a web browser that supports the Web-Serial API.

--- a/example/README.md
+++ b/example/README.md
@@ -5,8 +5,9 @@
 ## Features
 
 - **One-click flashing** - Just select your firmware and click Flash
-- **Auto-reset to bootloader** - Uses 1200 baud touch technique (like Arduino IDE)
-- **Progress tracking** - Real-time progress bar and live status log
+- **Progress tracking** - Real-time status logs and progress bar built into the UI.
+- **Auto-reset** - Uses 1200 baud-touch technique to automatically enter bootloader mode (like the Arduino IDE).
+- **Automatic Port Detection** - Attempts to automatically detect known USB vendor IDs while in bootloader mode to minimize necessary user interaction.
 
 ## Quick Start
 
@@ -86,5 +87,5 @@ That's it! Your device should now be running the new firmware.
   SUBSYSTEM=="usb", ATTR{idVendor}=="2341", MODE="0666"
   ```
 
-### Test Rig
-This was tested and confirmed to successfully flash firmware to an **Adafruit Feather M0** via Chromium v142 on Mac OS 13.7. 
+---
+#### Note: This was tested and confirmed to successfully flash firmware to an **Adafruit Feather M0** via **Chromium v142** on **Mac OS 13.7**. Wider compatibility is expected but has not yet been tested.

--- a/example/README.md
+++ b/example/README.md
@@ -1,6 +1,6 @@
 # BOSSA Web Firmware Flasher
 
-### A one-click web-based firmware flasher for ATSAMD21G-based devices using the Web Serial API. 
+### A simple web-based firmware flasher for ATSAMD21G-based devices using the Web Serial API. 
 
 ## Features
 

--- a/example/README.md
+++ b/example/README.md
@@ -49,8 +49,15 @@ python -m http.server 8000 --directory example
 
 That's it! Your device should now be running the new firmware.
 
+## Troubleshooting
 
-## Browser Requirements
+### "Device not supported" Error
+
+- Make sure you have an ATSAMD21-based device
+- Try manually entering bootloader mode (double-tap reset)
+- Check that you're selecting the correct serial port
+
+### Browser Shows "Not Supported" Error
 
 | Browser | Minimum Version | Status |
 |---------|-----------------|--------|
@@ -62,19 +69,6 @@ That's it! Your device should now be running the new firmware.
 | Firefox | - | ❌ Not supported |
 | Safari | - | ❌ Not supported |
 | Internet Explorer | - | ❌ Not supported |
-
-## Troubleshooting
-
-### "Device not supported" Error
-
-- Make sure you have an ATSAMD21-based device
-- Try manually entering bootloader mode (double-tap reset)
-- Check that you're selecting the correct serial port
-
-### Browser Shows "Not Supported" Error
-
-- Use Chrome, Edge, or Opera
-- Make sure you're using a recent version (Chrome 89+, Edge 89+, Opera 75+)
 
 ### Auto-Reset Fails
 

--- a/example/README.md
+++ b/example/README.md
@@ -1,30 +1,12 @@
 # BOSSA Web Firmware Flasher
 
-A one-click web-based firmware flasher for ATSAMD21G-based devices using the Web Serial API.
+### A one-click web-based firmware flasher for ATSAMD21G-based devices using the Web Serial API. 
 
 ## Features
 
 - **One-click flashing** - Just select your firmware and click Flash
 - **Auto-reset to bootloader** - Uses 1200 baud touch technique (like Arduino IDE)
-- **Progress tracking** - Real-time progress bar and status log
-- **No drivers needed** - Works directly in your browser
-
-## Supported Devices
-
-- Adafruit Feather M0
-- Arduino Zero
-- Arduino MKR series
-- Other ATSAMD21-based boards
-
-## Browser Requirements
-
-| Browser | Minimum Version | Status |
-|---------|-----------------|--------|
-| Chrome | 89+ | ✅ Supported |
-| Edge | 89+ | ✅ Supported |
-| Opera | 75+ | ✅ Supported |
-| Firefox | - | ❌ Not supported |
-| Safari | - | ❌ Not supported |
+- **Progress tracking** - Real-time progress bar and live status log
 
 ## Quick Start
 
@@ -67,31 +49,19 @@ python -m http.server 8000 --directory example
 
 That's it! Your device should now be running the new firmware.
 
-## How Auto-Reset Works
 
-The flasher uses the "1200 baud touch" technique:
+## Browser Requirements
 
-1. Opens your device's serial port at 1200 baud
-2. Toggles the DTR signal to trigger a reset
-3. Waits for the bootloader to enumerate
-4. Connects to the bootloader port for flashing
-
-This is the same technique used by the Arduino IDE.
-
-### If Auto-Reset Doesn't Work
-
-Some devices or USB adapters may not support the auto-reset. In this case:
-
-1. **Manually enter bootloader mode** by double-tapping the reset button
-2. The LED should pulse/fade indicating bootloader mode
-3. Then click "Flash Firmware" and select the bootloader port
-
-## Test Firmware
-
-A test firmware file is included in the repository root:
-- **File:** `blink_1000-feather_m0.bin`
-- **Description:** Blinks the LED at 1000ms intervals
-- **Target:** Adafruit Feather M0
+| Browser | Minimum Version | Status |
+|---------|-----------------|--------|
+| Chrome | 89+ | ✅ Supported |
+| Edge | 89+ | ✅ Supported |
+| Opera | 75+ | ✅ Supported |
+| Brave | 1.22+ | ✅ Supported |
+| Vivaldi | 3.7+ | ✅ Supported |
+| Firefox | - | ❌ Not supported |
+| Safari | - | ❌ Not supported |
+| Internet Explorer | - | ❌ Not supported |
 
 ## Troubleshooting
 
@@ -106,16 +76,8 @@ A test firmware file is included in the repository root:
 - Use Chrome, Edge, or Opera
 - Make sure you're using a recent version (Chrome 89+, Edge 89+, Opera 75+)
 
-### Flash Fails Midway
+### Auto-Reset Fails
 
-- Make sure the device stays connected during flashing
-- Don't move or bump the USB cable
-- Try a different USB cable or port
-- Re-enter bootloader mode and try again
-
-### Auto-Reset Not Working
-
-- Not all USB-to-serial adapters support DTR toggling
 - Try manually double-tapping the reset button before flashing
 - Some boards may need a longer delay - try waiting a few seconds after reset
 
@@ -130,37 +92,5 @@ A test firmware file is included in the repository root:
   SUBSYSTEM=="usb", ATTR{idVendor}=="2341", MODE="0666"
   ```
 
-## Development
-
-### Project Structure
-
-```
-example/
-├── index.html      # Main HTML page
-├── styles.css      # Styling
-├── bundle.js       # Built JavaScript (generated)
-└── README.md       # This file
-
-src/
-├── example.ts      # TypeScript source for the flasher UI
-├── samba.ts        # SAM-BA protocol implementation
-├── device.ts       # Device detection
-├── flasher.ts      # Flashing logic
-└── ...
-```
-
-### Rebuilding
-
-After modifying `src/example.ts`:
-
-```bash
-npm run build:example
-```
-
-### Debugging
-
-Open browser DevTools (F12) to see detailed logs in the console.
-
-## License
-
-BSD-3-Clause - See LICENSE file in the repository root.
+### Test Rig
+This was tested and confirmed to successfully flash firmware to an **Adafruit Feather M0** via Chromium v142 on Mac OS 13.7. 

--- a/example/README.md
+++ b/example/README.md
@@ -1,6 +1,13 @@
-# BOSSA Web Firmware Flasher Example
+# BOSSA Web Firmware Flasher
 
-A simple web-based firmware flasher for ATSAMD21G-based devices using the Web Serial API.
+A one-click web-based firmware flasher for ATSAMD21G-based devices using the Web Serial API.
+
+## Features
+
+- **One-click flashing** - Just select your firmware and click Flash
+- **Auto-reset to bootloader** - Uses 1200 baud touch technique (like Arduino IDE)
+- **Progress tracking** - Real-time progress bar and status log
+- **No drivers needed** - Works directly in your browser
 
 ## Supported Devices
 
@@ -27,8 +34,10 @@ A simple web-based firmware flasher for ATSAMD21G-based devices using the Web Se
 # Install dependencies
 npm install
 
-# Build the library and example
+# Build the library
 npm run build
+
+# Build the example
 npm run build:example
 ```
 
@@ -48,26 +57,34 @@ python -m http.server 8000 --directory example
 
 ### 3. Flash Your Device
 
-1. **Enter Bootloader Mode**
-   - Double-tap the reset button on your device
-   - The LED should pulse/fade indicating bootloader mode
-   - A new serial port will appear
+1. **Select Firmware** - Click "Select Firmware (.bin)" and choose your compiled .bin file
+2. **Click "Flash Firmware"** - The tool will automatically:
+   - Ask you to select your device's serial port
+   - Reset the device into bootloader mode
+   - Connect to the bootloader
+   - Erase and write the firmware
+   - Reset the device to run the new code
 
-2. **Connect**
-   - Click "Connect Device"
-   - Select the bootloader serial port from the browser dialog
-   - On macOS: looks like `cu.usbmodem*`
-   - On Windows: `COM*`
-   - On Linux: `/dev/ttyACM*`
+That's it! Your device should now be running the new firmware.
 
-3. **Select Firmware**
-   - Click "Select Firmware (.bin)"
-   - Choose your compiled .bin file
+## How Auto-Reset Works
 
-4. **Flash**
-   - Click "Flash Firmware"
-   - Wait for the process to complete
-   - The device will automatically reset and run the new firmware
+The flasher uses the "1200 baud touch" technique:
+
+1. Opens your device's serial port at 1200 baud
+2. Toggles the DTR signal to trigger a reset
+3. Waits for the bootloader to enumerate
+4. Connects to the bootloader port for flashing
+
+This is the same technique used by the Arduino IDE.
+
+### If Auto-Reset Doesn't Work
+
+Some devices or USB adapters may not support the auto-reset. In this case:
+
+1. **Manually enter bootloader mode** by double-tapping the reset button
+2. The LED should pulse/fade indicating bootloader mode
+3. Then click "Flash Firmware" and select the bootloader port
 
 ## Test Firmware
 
@@ -80,14 +97,9 @@ A test firmware file is included in the repository root:
 
 ### "Device not supported" Error
 
-- Make sure the device is in **bootloader mode** (double-tap reset)
-- The device should show a different serial port than normal operation
-- Try unplugging and reconnecting the device
-
-### "No port selected" Message
-
-- You cancelled the port selection dialog
-- Click "Connect Device" again and select a port
+- Make sure you have an ATSAMD21-based device
+- Try manually entering bootloader mode (double-tap reset)
+- Check that you're selecting the correct serial port
 
 ### Browser Shows "Not Supported" Error
 
@@ -101,12 +113,22 @@ A test firmware file is included in the repository root:
 - Try a different USB cable or port
 - Re-enter bootloader mode and try again
 
+### Auto-Reset Not Working
+
+- Not all USB-to-serial adapters support DTR toggling
+- Try manually double-tapping the reset button before flashing
+- Some boards may need a longer delay - try waiting a few seconds after reset
+
 ### Device Not Showing in Port List
 
-- Check that the device is in bootloader mode
+- Check that the device is properly connected
 - Try a different USB port
-- On Linux, you may need to add udev rules for your device
-- On macOS, the port should appear automatically
+- On Linux, you may need to add udev rules:
+  ```bash
+  # Create /etc/udev/rules.d/99-arduino.rules
+  SUBSYSTEM=="usb", ATTR{idVendor}=="239a", MODE="0666"
+  SUBSYSTEM=="usb", ATTR{idVendor}=="2341", MODE="0666"
+  ```
 
 ## Development
 

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,144 @@
+# BOSSA Web Firmware Flasher Example
+
+A simple web-based firmware flasher for ATSAMD21G-based devices using the Web Serial API.
+
+## Supported Devices
+
+- Adafruit Feather M0
+- Arduino Zero
+- Arduino MKR series
+- Other ATSAMD21-based boards
+
+## Browser Requirements
+
+| Browser | Minimum Version | Status |
+|---------|-----------------|--------|
+| Chrome | 89+ | ✅ Supported |
+| Edge | 89+ | ✅ Supported |
+| Opera | 75+ | ✅ Supported |
+| Firefox | - | ❌ Not supported |
+| Safari | - | ❌ Not supported |
+
+## Quick Start
+
+### 1. Build the Project
+
+```bash
+# Install dependencies
+npm install
+
+# Build the library and example
+npm run build
+npm run build:example
+```
+
+### 2. Serve the Example
+
+```bash
+# Serve locally (opens http://localhost:3000)
+npm run serve
+```
+
+Or use any static file server:
+```bash
+npx serve example
+# or
+python -m http.server 8000 --directory example
+```
+
+### 3. Flash Your Device
+
+1. **Enter Bootloader Mode**
+   - Double-tap the reset button on your device
+   - The LED should pulse/fade indicating bootloader mode
+   - A new serial port will appear
+
+2. **Connect**
+   - Click "Connect Device"
+   - Select the bootloader serial port from the browser dialog
+   - On macOS: looks like `cu.usbmodem*`
+   - On Windows: `COM*`
+   - On Linux: `/dev/ttyACM*`
+
+3. **Select Firmware**
+   - Click "Select Firmware (.bin)"
+   - Choose your compiled .bin file
+
+4. **Flash**
+   - Click "Flash Firmware"
+   - Wait for the process to complete
+   - The device will automatically reset and run the new firmware
+
+## Test Firmware
+
+A test firmware file is included in the repository root:
+- **File:** `blink_1000-feather_m0.bin`
+- **Description:** Blinks the LED at 1000ms intervals
+- **Target:** Adafruit Feather M0
+
+## Troubleshooting
+
+### "Device not supported" Error
+
+- Make sure the device is in **bootloader mode** (double-tap reset)
+- The device should show a different serial port than normal operation
+- Try unplugging and reconnecting the device
+
+### "No port selected" Message
+
+- You cancelled the port selection dialog
+- Click "Connect Device" again and select a port
+
+### Browser Shows "Not Supported" Error
+
+- Use Chrome, Edge, or Opera
+- Make sure you're using a recent version (Chrome 89+, Edge 89+, Opera 75+)
+
+### Flash Fails Midway
+
+- Make sure the device stays connected during flashing
+- Don't move or bump the USB cable
+- Try a different USB cable or port
+- Re-enter bootloader mode and try again
+
+### Device Not Showing in Port List
+
+- Check that the device is in bootloader mode
+- Try a different USB port
+- On Linux, you may need to add udev rules for your device
+- On macOS, the port should appear automatically
+
+## Development
+
+### Project Structure
+
+```
+example/
+├── index.html      # Main HTML page
+├── styles.css      # Styling
+├── bundle.js       # Built JavaScript (generated)
+└── README.md       # This file
+
+src/
+├── example.ts      # TypeScript source for the flasher UI
+├── samba.ts        # SAM-BA protocol implementation
+├── device.ts       # Device detection
+├── flasher.ts      # Flashing logic
+└── ...
+```
+
+### Rebuilding
+
+After modifying `src/example.ts`:
+
+```bash
+npm run build:example
+```
+
+### Debugging
+
+Open browser DevTools (F12) to see detailed logs in the console.
+
+## License
+
+BSD-3-Clause - See LICENSE file in the repository root.

--- a/example/index.html
+++ b/example/index.html
@@ -9,12 +9,12 @@
 <body>
     <div class="container">
         <header>
-            <h1>🔌 BOSSA Web Firmware Flasher</h1>
+            <h1>BOSSA Web Firmware Flasher</h1>
             <p class="subtitle">One-click firmware flashing for ATSAMD21G-based devices</p>
         </header>
 
         <section class="instructions">
-            <h2>📋 How to Use</h2>
+            <h2>How to Use</h2>
             <ol>
                 <li><strong>Select your firmware file</strong> (.bin format from Arduino or PlatformIO)</li>
                 <li><strong>Click "Flash Firmware"</strong> - The tool will:
@@ -44,7 +44,7 @@
 
             <div class="control-row">
                 <button id="flashBtn" class="btn btn-primary btn-large" disabled>
-                    ⚡ Flash Firmware
+                    Flash Firmware
                 </button>
             </div>
 
@@ -52,7 +52,7 @@
         </section>
 
         <section class="progress-section">
-            <h2>📊 Progress</h2>
+            <h2>Progress</h2>
             <div class="progress-container">
                 <progress id="progressBar" value="0" max="100"></progress>
                 <span id="progressText">0%</span>
@@ -60,19 +60,21 @@
         </section>
 
         <section class="log-section">
-            <h2>📝 Status Log</h2>
+            <h2>Status Log</h2>
             <div id="statusLog" class="status-log"></div>
         </section>
 
-        <footer>
+        <footer style="text-align: left;">
             <p>
-                <strong>Supported devices:</strong> ATSAMD21-based boards (Adafruit Feather M0, Arduino Zero, MKR series)
+                <h3>Supported devices:</h3> 
+                ATSAMD21-based boards (<strong>Adafruit Feather M0</strong>, Arduino Zero, MKR series)
             </p>
             <p>
-                <strong>Browser support:</strong> Chrome 89+, Edge 89+, Opera 75+
+                <h3> Browser support: </h3>
+                Chromium-based browsers (<strong>Brave 1.22+</strong>, Chrome 89+, Edge 89+, Opera 76+, Vivaldi 3.7+)
             </p>
             <p class="github-link">
-                <a href="https://github.com/ma-ku/bossa-web" target="_blank">View on GitHub</a>
+                <a href="https://github.com/rubendax/bossa-web/tree/main/example" target="_blank">View on GitHub</a>
             </p>
         </footer>
     </div>

--- a/example/index.html
+++ b/example/index.html
@@ -1,11 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0">
     <title>BOSSA Web Firmware Flasher</title>
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet"
+          href="styles.css">
 </head>
+
 <body>
     <div class="container">
         <header>
@@ -27,58 +31,55 @@
                 </li>
             </ol>
             <p class="note">
-                <strong>Note:</strong> If auto-reset doesn't work, manually double-tap the reset button on your device 
-                before selecting the port.
+                <strong>Supported devices:</strong><br>
+                ATSAMD21-based boards (Adafruit Feather M0, Arduino Zero, MKR series)
+                <br><br>
+                <strong> Supported browsers: </strong><br>
+                Chromium-based browsers (Brave 1.22+, Chrome 89+, Edge 89+, Opera 76+, Vivaldi 3.7+)
             </p>
         </section>
 
         <section class="controls">
             <div class="control-row">
-                <label for="fileInput" class="file-label">
-                    <span class="file-label-icon">📁</span>
+                <label for="fileInput"
+                       class="file-label">
+                    <span class="btn-icon">📁</span>
                     <span class="file-label-text">Select Firmware (.bin)</span>
-                    <input type="file" id="fileInput" accept=".bin">
+                    <div id="fileInfo"
+                         class="file-info"></div>
+                    <input type="file"
+                           id="fileInput"
+                           accept=".bin">
                 </label>
-                <div id="fileInfo" class="file-info"></div>
             </div>
 
             <div class="control-row">
-                <button id="flashBtn" class="btn btn-primary btn-large" disabled>
-                    ⚡ Flash Firmware
+                <button id="flashBtn"
+                        class="btn btn-primary btn-large"
+                        disabled>
+                    <span class="btn-icon">⚡</span> <span>Flash Firmware</span>
                 </button>
             </div>
-
-            <div id="deviceInfo" class="device-info"></div>
         </section>
 
         <section class="progress-section">
             <h2>Progress</h2>
             <div class="progress-container">
-                <progress id="progressBar" value="0" max="100"></progress>
+                <progress id="progressBar"
+                          value="0"
+                          max="100"></progress>
                 <span id="progressText">0%</span>
             </div>
         </section>
 
         <section class="log-section">
             <h2>Status Log</h2>
-            <div id="statusLog" class="status-log"></div>
+            <div id="statusLog"
+                 class="status-log"></div>
         </section>
-
-        <footer style="text-align: left;">
-            <p>
-                <h3>Supported devices:</h3> 
-                ATSAMD21-based boards (<strong>Adafruit Feather M0</strong>, Arduino Zero, MKR series)
-            </p>
-            <p>
-                <h3> Browser support: </h3>
-                Chromium-based browsers (<strong>Brave 1.22+</strong>, Chrome 89+, Edge 89+, Opera 76+, Vivaldi 3.7+)
-            </p>
-            <p class="github-link">
-                <a href="https://github.com/rubendax/bossa-web/tree/main/example" target="_blank">View on GitHub</a>
-            </p>
-        </footer>
     </div>
 
     <script src="bundle.js"></script>
 </body>
+
 </html>

--- a/example/index.html
+++ b/example/index.html
@@ -10,13 +10,13 @@
     <div class="container">
         <header>
             <h1>BOSSA Web Firmware Flasher</h1>
-            <p class="subtitle">One-click firmware flashing for ATSAMD21G-based devices</p>
+            <p class="subtitle">Easy firmware flashing for ATSAMD21-based devices</p>
         </header>
 
         <section class="instructions">
             <h2>How to Use</h2>
             <ol>
-                <li><strong>Select your firmware file</strong> (.bin format from Arduino or PlatformIO)</li>
+                <li><strong>Select your firmware file</strong> (.bin from Arduino IDE or PlatformIO)</li>
                 <li><strong>Click "Flash Firmware"</strong> - The tool will:
                     <ul>
                         <li>Ask you to select your device's serial port</li>

--- a/example/index.html
+++ b/example/index.html
@@ -44,7 +44,7 @@
 
             <div class="control-row">
                 <button id="flashBtn" class="btn btn-primary btn-large" disabled>
-                    Flash Firmware
+                    ⚡ Flash Firmware
                 </button>
             </div>
 

--- a/example/index.html
+++ b/example/index.html
@@ -10,36 +10,45 @@
     <div class="container">
         <header>
             <h1>🔌 BOSSA Web Firmware Flasher</h1>
-            <p class="subtitle">Flash firmware to ATSAMD21G-based devices via Web Serial API</p>
+            <p class="subtitle">One-click firmware flashing for ATSAMD21G-based devices</p>
         </header>
 
         <section class="instructions">
-            <h2>📋 Instructions</h2>
+            <h2>📋 How to Use</h2>
             <ol>
-                <li><strong>Enter Bootloader Mode:</strong> Double-tap the reset button on your device. 
-                    The LED should pulse/fade indicating bootloader mode.</li>
-                <li><strong>Connect:</strong> Click the "Connect Device" button and select the bootloader serial port.</li>
-                <li><strong>Select Firmware:</strong> Choose your .bin firmware file.</li>
-                <li><strong>Flash:</strong> Click "Flash Firmware" and wait for completion.</li>
+                <li><strong>Select your firmware file</strong> (.bin format from Arduino or PlatformIO)</li>
+                <li><strong>Click "Flash Firmware"</strong> - The tool will:
+                    <ul>
+                        <li>Ask you to select your device's serial port</li>
+                        <li>Automatically reset your device into bootloader mode</li>
+                        <li>Flash the firmware</li>
+                        <li>Reset the device to run the new code</li>
+                    </ul>
+                </li>
             </ol>
+            <p class="note">
+                <strong>Note:</strong> If auto-reset doesn't work, manually double-tap the reset button on your device 
+                before selecting the port.
+            </p>
         </section>
 
         <section class="controls">
             <div class="control-row">
-                <button id="connectBtn" class="btn btn-primary">Connect Device</button>
-                <div id="deviceInfo" class="device-info"></div>
-            </div>
-
-            <div class="control-row">
                 <label for="fileInput" class="file-label">
+                    <span class="file-label-icon">📁</span>
                     <span class="file-label-text">Select Firmware (.bin)</span>
-                    <input type="file" id="fileInput" accept=".bin" disabled>
+                    <input type="file" id="fileInput" accept=".bin">
                 </label>
+                <div id="fileInfo" class="file-info"></div>
             </div>
 
             <div class="control-row">
-                <button id="flashBtn" class="btn btn-success" disabled>Flash Firmware</button>
+                <button id="flashBtn" class="btn btn-primary btn-large" disabled>
+                    ⚡ Flash Firmware
+                </button>
             </div>
+
+            <div id="deviceInfo" class="device-info"></div>
         </section>
 
         <section class="progress-section">
@@ -57,7 +66,7 @@
 
         <footer>
             <p>
-                <strong>Supported devices:</strong> ATSAMD21-based boards (Adafruit Feather M0, Arduino Zero, etc.)
+                <strong>Supported devices:</strong> ATSAMD21-based boards (Adafruit Feather M0, Arduino Zero, MKR series)
             </p>
             <p>
                 <strong>Browser support:</strong> Chrome 89+, Edge 89+, Opera 75+

--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>BOSSA Web Firmware Flasher</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>🔌 BOSSA Web Firmware Flasher</h1>
+            <p class="subtitle">Flash firmware to ATSAMD21G-based devices via Web Serial API</p>
+        </header>
+
+        <section class="instructions">
+            <h2>📋 Instructions</h2>
+            <ol>
+                <li><strong>Enter Bootloader Mode:</strong> Double-tap the reset button on your device. 
+                    The LED should pulse/fade indicating bootloader mode.</li>
+                <li><strong>Connect:</strong> Click the "Connect Device" button and select the bootloader serial port.</li>
+                <li><strong>Select Firmware:</strong> Choose your .bin firmware file.</li>
+                <li><strong>Flash:</strong> Click "Flash Firmware" and wait for completion.</li>
+            </ol>
+        </section>
+
+        <section class="controls">
+            <div class="control-row">
+                <button id="connectBtn" class="btn btn-primary">Connect Device</button>
+                <div id="deviceInfo" class="device-info"></div>
+            </div>
+
+            <div class="control-row">
+                <label for="fileInput" class="file-label">
+                    <span class="file-label-text">Select Firmware (.bin)</span>
+                    <input type="file" id="fileInput" accept=".bin" disabled>
+                </label>
+            </div>
+
+            <div class="control-row">
+                <button id="flashBtn" class="btn btn-success" disabled>Flash Firmware</button>
+            </div>
+        </section>
+
+        <section class="progress-section">
+            <h2>📊 Progress</h2>
+            <div class="progress-container">
+                <progress id="progressBar" value="0" max="100"></progress>
+                <span id="progressText">0%</span>
+            </div>
+        </section>
+
+        <section class="log-section">
+            <h2>📝 Status Log</h2>
+            <div id="statusLog" class="status-log"></div>
+        </section>
+
+        <footer>
+            <p>
+                <strong>Supported devices:</strong> ATSAMD21-based boards (Adafruit Feather M0, Arduino Zero, etc.)
+            </p>
+            <p>
+                <strong>Browser support:</strong> Chrome 89+, Edge 89+, Opera 75+
+            </p>
+            <p class="github-link">
+                <a href="https://github.com/ma-ku/bossa-web" target="_blank">View on GitHub</a>
+            </p>
+        </footer>
+    </div>
+
+    <script src="bundle.js"></script>
+</body>
+</html>

--- a/example/styles.css
+++ b/example/styles.css
@@ -115,6 +115,7 @@ section h2 {
 .control-row {
     display: flex;
     align-items: center;
+    justify-content: center;
     gap: 15px;
     flex-wrap: wrap;
 }

--- a/example/styles.css
+++ b/example/styles.css
@@ -1,0 +1,306 @@
+/* BOSSA Web Firmware Flasher Styles */
+
+:root {
+    --primary-color: #007bff;
+    --success-color: #28a745;
+    --warning-color: #ffc107;
+    --error-color: #dc3545;
+    --bg-color: #f5f5f5;
+    --card-bg: #ffffff;
+    --text-color: #333333;
+    --text-muted: #666666;
+    --border-color: #dddddd;
+    --log-bg: #1e1e1e;
+    --log-text: #d4d4d4;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    margin: 0;
+    padding: 20px;
+    line-height: 1.6;
+}
+
+.container {
+    max-width: 800px;
+    margin: 0 auto;
+    background-color: var(--card-bg);
+    border-radius: 12px;
+    padding: 30px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}
+
+header {
+    text-align: center;
+    margin-bottom: 30px;
+    padding-bottom: 20px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+header h1 {
+    margin: 0 0 10px 0;
+    font-size: 2em;
+    color: var(--primary-color);
+}
+
+.subtitle {
+    color: var(--text-muted);
+    margin: 0;
+}
+
+section {
+    margin-bottom: 25px;
+}
+
+section h2 {
+    font-size: 1.2em;
+    margin: 0 0 15px 0;
+    color: var(--text-color);
+}
+
+/* Instructions */
+.instructions {
+    background-color: #f8f9fa;
+    padding: 20px;
+    border-radius: 8px;
+    border-left: 4px solid var(--primary-color);
+}
+
+.instructions ol {
+    margin: 0;
+    padding-left: 20px;
+}
+
+.instructions li {
+    margin-bottom: 10px;
+}
+
+.instructions li:last-child {
+    margin-bottom: 0;
+}
+
+/* Controls */
+.controls {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+}
+
+.control-row {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+    flex-wrap: wrap;
+}
+
+.btn {
+    padding: 12px 24px;
+    font-size: 1em;
+    font-weight: 600;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.btn-primary {
+    background-color: var(--primary-color);
+    color: white;
+}
+
+.btn-primary:hover:not(:disabled) {
+    background-color: #0056b3;
+}
+
+.btn-success {
+    background-color: var(--success-color);
+    color: white;
+}
+
+.btn-success:hover:not(:disabled) {
+    background-color: #1e7e34;
+}
+
+/* File input */
+.file-label {
+    display: inline-block;
+    padding: 12px 24px;
+    background-color: #6c757d;
+    color: white;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.file-label:hover {
+    background-color: #5a6268;
+}
+
+.file-label input[type="file"] {
+    display: none;
+}
+
+.file-label input[type="file"]:disabled + .file-label-text {
+    opacity: 0.5;
+}
+
+/* Device info */
+.device-info {
+    display: none;
+    padding: 10px 15px;
+    background-color: #e7f5e7;
+    border: 1px solid var(--success-color);
+    border-radius: 6px;
+    color: #155724;
+    font-size: 0.9em;
+}
+
+/* Progress */
+.progress-section {
+    background-color: #f8f9fa;
+    padding: 20px;
+    border-radius: 8px;
+}
+
+.progress-container {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+}
+
+progress {
+    flex: 1;
+    height: 25px;
+    border-radius: 12px;
+    overflow: hidden;
+    appearance: none;
+    -webkit-appearance: none;
+}
+
+progress::-webkit-progress-bar {
+    background-color: #e0e0e0;
+    border-radius: 12px;
+}
+
+progress::-webkit-progress-value {
+    background-color: var(--success-color);
+    border-radius: 12px;
+    transition: width 0.3s ease;
+}
+
+progress::-moz-progress-bar {
+    background-color: var(--success-color);
+    border-radius: 12px;
+}
+
+#progressText {
+    min-width: 50px;
+    font-weight: 600;
+    color: var(--text-muted);
+}
+
+/* Status log */
+.log-section h2 {
+    margin-bottom: 10px;
+}
+
+.status-log {
+    background-color: var(--log-bg);
+    color: var(--log-text);
+    padding: 15px;
+    border-radius: 8px;
+    font-family: 'Monaco', 'Menlo', 'Consolas', monospace;
+    font-size: 0.85em;
+    height: 250px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+}
+
+.log-entry {
+    margin-bottom: 4px;
+    padding: 2px 0;
+}
+
+.log-info {
+    color: var(--log-text);
+}
+
+.log-success {
+    color: #4caf50;
+}
+
+.log-error {
+    color: #f44336;
+}
+
+.log-warning {
+    color: #ff9800;
+}
+
+/* Footer */
+footer {
+    margin-top: 30px;
+    padding-top: 20px;
+    border-top: 1px solid var(--border-color);
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 0.9em;
+}
+
+footer p {
+    margin: 5px 0;
+}
+
+footer a {
+    color: var(--primary-color);
+    text-decoration: none;
+}
+
+footer a:hover {
+    text-decoration: underline;
+}
+
+.github-link {
+    margin-top: 15px;
+}
+
+/* Responsive */
+@media (max-width: 600px) {
+    body {
+        padding: 10px;
+    }
+
+    .container {
+        padding: 20px;
+    }
+
+    header h1 {
+        font-size: 1.5em;
+    }
+
+    .control-row {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .btn, .file-label {
+        width: 100%;
+        text-align: center;
+    }
+
+    .device-info {
+        width: 100%;
+    }
+}

--- a/example/styles.css
+++ b/example/styles.css
@@ -73,7 +73,7 @@ section h2 {
 }
 
 .instructions ol {
-    margin: 0;
+    margin: 0 0 15px 0;
     padding-left: 20px;
 }
 
@@ -83,6 +83,26 @@ section h2 {
 
 .instructions li:last-child {
     margin-bottom: 0;
+}
+
+.instructions ul {
+    margin-top: 8px;
+    padding-left: 20px;
+    color: var(--text-muted);
+}
+
+.instructions ul li {
+    margin-bottom: 4px;
+}
+
+.instructions .note {
+    margin: 15px 0 0 0;
+    padding: 10px 15px;
+    background-color: #fff3cd;
+    border: 1px solid var(--warning-color);
+    border-radius: 6px;
+    color: #856404;
+    font-size: 0.9em;
 }
 
 /* Controls */
@@ -132,6 +152,12 @@ section h2 {
     background-color: #1e7e34;
 }
 
+.btn-large {
+    padding: 16px 32px;
+    font-size: 1.2em;
+    width: 100%;
+}
+
 /* File input */
 .file-label {
     display: inline-block;
@@ -155,6 +181,23 @@ section h2 {
     opacity: 0.5;
 }
 
+.file-label-icon {
+    margin-right: 8px;
+}
+
+/* File info */
+.file-info {
+    display: none;
+    padding: 10px 15px;
+    background-color: #e3f2fd;
+    border: 1px solid #2196f3;
+    border-radius: 6px;
+    color: #1565c0;
+    font-size: 0.9em;
+    margin-top: 10px;
+    width: 100%;
+}
+
 /* Device info */
 .device-info {
     display: none;
@@ -164,6 +207,8 @@ section h2 {
     border-radius: 6px;
     color: #155724;
     font-size: 0.9em;
+    margin-top: 15px;
+    width: 100%;
 }
 
 /* Progress */

--- a/example/styles.css
+++ b/example/styles.css
@@ -96,13 +96,8 @@ section h2 {
 }
 
 .instructions .note {
-    margin: 15px 0 0 0;
-    padding: 10px 15px;
-    background-color: #fff3cd;
-    border: 1px solid var(--warning-color);
-    border-radius: 6px;
-    color: #856404;
-    font-size: 0.9em;
+    margin: 0;
+    font-size: 0.8em;
 }
 
 /* Controls */
@@ -110,6 +105,9 @@ section h2 {
     display: flex;
     flex-direction: column;
     gap: 15px;
+    margin-top: 30px;
+    padding-top: 20px;
+    border-top: 1px solid var(--border-color);
 }
 
 .control-row {
@@ -163,15 +161,17 @@ section h2 {
 .file-label {
     display: inline-block;
     padding: 12px 24px;
-    background-color: #6c757d;
+    background-color: var(--primary-color);
     color: white;
     border-radius: 6px;
     cursor: pointer;
     transition: background-color 0.2s ease;
+    text-align: center;
+    font-weight: bold;
 }
 
 .file-label:hover {
-    background-color: #5a6268;
+    background-color: #0056b3;
 }
 
 .file-label input[type="file"] {
@@ -182,21 +182,23 @@ section h2 {
     opacity: 0.5;
 }
 
-.file-label-icon {
+.btn-icon {
     margin-right: 8px;
 }
 
 /* File info */
 .file-info {
     display: none;
-    padding: 10px 15px;
+    padding: 2px 5px;
     background-color: #e3f2fd;
-    border: 1px solid #2196f3;
     border-radius: 6px;
     color: #1565c0;
-    font-size: 0.9em;
-    margin-top: 10px;
-    width: 100%;
+    font-size: 0.7em;
+    margin-top: 5px;
+    margin-left: auto;
+    margin-right: auto;
+    width: fit-content;
+    text-align: center;
 }
 
 /* Device info */

--- a/example/styles.css
+++ b/example/styles.css
@@ -201,19 +201,6 @@ section h2 {
     text-align: center;
 }
 
-/* Device info */
-.device-info {
-    display: none;
-    padding: 10px 15px;
-    background-color: #e7f5e7;
-    border: 1px solid var(--success-color);
-    border-radius: 6px;
-    color: #155724;
-    font-size: 0.9em;
-    margin-top: 15px;
-    width: 100%;
-}
-
 /* Progress */
 .progress-section {
     background-color: #f8f9fa;
@@ -297,33 +284,6 @@ progress::-moz-progress-bar {
     color: #ff9800;
 }
 
-/* Footer */
-footer {
-    margin-top: 30px;
-    padding-top: 20px;
-    border-top: 1px solid var(--border-color);
-    text-align: center;
-    color: var(--text-muted);
-    font-size: 0.9em;
-}
-
-footer p {
-    margin: 5px 0;
-}
-
-footer a {
-    color: var(--primary-color);
-    text-decoration: none;
-}
-
-footer a:hover {
-    text-decoration: underline;
-}
-
-.github-link {
-    margin-top: 30px;
-    text-align: center;
-}
 
 /* Responsive */
 @media (max-width: 600px) {

--- a/example/styles.css
+++ b/example/styles.css
@@ -318,7 +318,8 @@ footer a:hover {
 }
 
 .github-link {
-    margin-top: 15px;
+    margin-top: 30px;
+    text-align: center;
 }
 
 /* Responsive */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bossa-web",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bossa-web",
-      "version": "0.9.6",
+      "version": "0.9.7",
       "license": "BSD-3",
       "dependencies": {
         "@types/events": "^3.0.0",
@@ -29,6 +29,7 @@
         "sinon": "^11.1.2",
         "sinon-chai": "^3.7.0",
         "source-map-support": "^0.5.20",
+        "ts-add-js-extension": "^1.6.4",
         "ts-node": "^10.4.0",
         "tslint": "^6.1.3",
         "typedoc": "^0.15.8",
@@ -1992,6 +1993,33 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/ts-add-js-extension": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ts-add-js-extension/-/ts-add-js-extension-1.6.4.tgz",
+      "integrity": "sha512-iY0rS5vLbleT4KPEq6ICdHJew+2wyXSK1wsB7HAChiMSQONRuVP7BY1q5k6gVzPXrrtWzV5qEgVujwj1nnFN7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "typescript": "^5.4.3"
+      },
+      "bin": {
+        "ts-add-js-extension": "build/cjs/bin.js"
+      }
+    },
+    "node_modules/ts-add-js-extension/node_modules/typescript": {
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
@@ -3915,6 +3943,23 @@
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        }
+      }
+    },
+    "ts-add-js-extension": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ts-add-js-extension/-/ts-add-js-extension-1.6.4.tgz",
+      "integrity": "sha512-iY0rS5vLbleT4KPEq6ICdHJew+2wyXSK1wsB7HAChiMSQONRuVP7BY1q5k6gVzPXrrtWzV5qEgVujwj1nnFN7Q==",
+      "dev": true,
+      "requires": {
+        "typescript": "^5.4.3"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "5.5.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+          "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -2,10 +2,8 @@
   "name": "bossa-web",
   "version": "0.9.7",
   "description": "Port of BOSSA to TypeScript with support for WebSerial API",
-  
   "main": "./dist/bossa-web.js",
-  "types": "./dist/bossa-web.d.ts",  
-  
+  "types": "./dist/bossa-web.d.ts",
   "keywords": [
     "bossa",
     "arduino",
@@ -13,15 +11,12 @@
     "web-serial",
     "browser"
   ],
-
   "author": {
     "name": "Mathias Kühn",
     "email": "mathias.kuehn@me.com"
   },
-  
   "license": "BSD-3",
   "readme": "README.md",
-
   "homepage": "https://github.com/ma-ku/bossa-web#readme",
   "repository": {
     "type": "git",
@@ -33,22 +28,20 @@
   "engines": {
     "node": ">=12"
   },
-
   "files": [
     "dist/",
     "LICENSE",
     "README.md",
     "package.json"
   ],
-
   "scripts": {
     "prebuild": "rimraf ./dist",
+    "patch": "ts-add-js-extension --dir=dist",
     "build": "tsc",
     "watch": "tsc --watch --preserveWatchOutput -p tsconfig.json",
     "test": "mocha -r ts-node/register src/*.spec.ts",
     "prepublishOnly": "npm run build"
   },
-
   "dependencies": {
     "@types/events": "^3.0.0",
     "@types/w3c-web-serial": "^1.0.2"
@@ -70,10 +63,11 @@
     "sinon": "^11.1.2",
     "sinon-chai": "^3.7.0",
     "source-map-support": "^0.5.20",
+    "ts-add-js-extension": "^1.6.4",
     "ts-node": "^10.4.0",
+    "tslint": "^6.1.3",
     "typedoc": "^0.15.8",
     "typedoc-md-theme": "^1.0.1",
-    "tslint": "^6.1.3",
     "typescript": "^4.4.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,14 +44,17 @@
   "scripts": {
     "prebuild": "rimraf ./dist",
     "build": "tsc",
+    "build:example": "esbuild src/example.ts --bundle --outfile=example/bundle.js --format=iife --global-name=BossaFlasher --target=es2018 --define:global=window",
     "watch": "tsc --watch --preserveWatchOutput -p tsconfig.json",
     "test": "mocha -r ts-node/register src/*.spec.ts",
+    "serve": "npx serve example",
     "prepublishOnly": "npm run build"
   },
 
   "dependencies": {
     "@types/events": "^3.0.0",
-    "@types/w3c-web-serial": "^1.0.2"
+    "@types/w3c-web-serial": "^1.0.2",
+    "buffer": "^6.0.3"
   },
   "devDependencies": {
     "@types/chai": "^4.2.21",
@@ -63,10 +66,12 @@
     "@types/xml2js": "^0.4.9",
     "chai": "^4.3.4",
     "cross-env": "^7.0.3",
+    "esbuild": "^0.19.8",
     "gh-pages": "^3.2.3",
     "mocha": "^9.1.0",
     "rimraf": "^3.0.2",
     "semver": "^7.3.5",
+    "serve": "^14.2.1",
     "sinon": "^11.1.2",
     "sinon-chai": "^3.7.0",
     "source-map-support": "^0.5.20",

--- a/src/device.ts
+++ b/src/device.ts
@@ -575,7 +575,7 @@ export class Device {
         case 0x60060005: // J19A
         case 0x60060007: // G19A
             this._family = Family.FAMILY_SAMD51;
-            flashPtr = null; new D5xNvmFlash(this._samba, "ATSAMD51x19", 1024, 512, 0x20004000, 0x20008000) ;
+            flashPtr = new D5xNvmFlash(this._samba, "ATSAMD51x19", 1024, 512, 0x20004000, 0x20008000) ;
             break;
 
         case 0x60060000: // P20A

--- a/src/example.ts
+++ b/src/example.ts
@@ -28,7 +28,6 @@ let fileInput: HTMLInputElement;
 let progressBar: HTMLProgressElement;
 let progressText: HTMLSpanElement;
 let statusLog: HTMLDivElement;
-let deviceInfo: HTMLDivElement;
 let fileInfo: HTMLDivElement;
 
 // State
@@ -86,14 +85,6 @@ function updateProgress(current: number, total: number): void {
 function resetProgress(): void {
     progressBar.value = 0;
     progressText.textContent = '0%';
-}
-
-/**
- * Update device info display
- */
-function updateDeviceInfo(info: string): void {
-    deviceInfo.textContent = info;
-    deviceInfo.style.display = info ? 'block' : 'none';
 }
 
 /**
@@ -225,7 +216,6 @@ async function flashFirmware(): Promise<void> {
     flashBtn.disabled = true;
     fileInput.disabled = true;
     resetProgress();
-    updateDeviceInfo('');
     
     let normalPort: SerialPort | null = null;
     let bootloaderPort: SerialPort | null = null;
@@ -329,7 +319,6 @@ async function flashFirmware(): Promise<void> {
         
         const sizeKB = Math.round(flash.totalSize / 1024);
         const info = `Device: ${flash.numPages} pages × ${flash.pageSize} bytes = ${sizeKB}KB flash`;
-        updateDeviceInfo(info);
         logSuccess(info);
         
         // Determine flash offset based on device family
@@ -440,7 +429,6 @@ function init(): void {
     progressBar = document.getElementById('progressBar') as HTMLProgressElement;
     progressText = document.getElementById('progressText') as HTMLSpanElement;
     statusLog = document.getElementById('statusLog') as HTMLDivElement;
-    deviceInfo = document.getElementById('deviceInfo') as HTMLDivElement;
     fileInfo = document.getElementById('fileInfo') as HTMLDivElement;
     
     // Set up event listeners

--- a/src/example.ts
+++ b/src/example.ts
@@ -1,0 +1,345 @@
+/**
+ * BOSSA Web Firmware Flasher Example
+ * 
+ * This module provides a simple web interface for flashing firmware
+ * to ATSAMD21G-based devices (like Adafruit Feather M0) using the Web Serial API.
+ */
+
+import { SamBA } from './samba';
+import { Device } from './device';
+import { Flasher, FlasherObserver } from './flasher';
+
+// UI Elements
+let connectBtn: HTMLButtonElement;
+let flashBtn: HTMLButtonElement;
+let fileInput: HTMLInputElement;
+let progressBar: HTMLProgressElement;
+let progressText: HTMLSpanElement;
+let statusLog: HTMLDivElement;
+let deviceInfo: HTMLDivElement;
+
+// State
+let serialPort: SerialPort | null = null;
+let samba: SamBA | null = null;
+let device: Device | null = null;
+let firmwareData: Uint8Array | null = null;
+
+/**
+ * Check if the browser supports Web Serial API
+ */
+function checkBrowserSupport(): boolean {
+    if (!('serial' in navigator)) {
+        logError('Web Serial API is not supported in this browser.');
+        logError('Please use Chrome, Edge, or Opera.');
+        return false;
+    }
+    return true;
+}
+
+/**
+ * Log a message to the status log
+ */
+function log(message: string, type: 'info' | 'success' | 'error' | 'warning' = 'info'): void {
+    const entry = document.createElement('div');
+    entry.className = `log-entry log-${type}`;
+    entry.textContent = `[${new Date().toLocaleTimeString()}] ${message}`;
+    statusLog.appendChild(entry);
+    statusLog.scrollTop = statusLog.scrollHeight;
+    console.log(`[${type.toUpperCase()}] ${message}`);
+}
+
+function logError(message: string): void {
+    log(message, 'error');
+}
+
+function logSuccess(message: string): void {
+    log(message, 'success');
+}
+
+function logWarning(message: string): void {
+    log(message, 'warning');
+}
+
+/**
+ * Update the progress bar
+ */
+function updateProgress(current: number, total: number): void {
+    const percent = Math.round((current / total) * 100);
+    progressBar.value = percent;
+    progressText.textContent = `${percent}%`;
+}
+
+/**
+ * Reset progress bar to zero
+ */
+function resetProgress(): void {
+    progressBar.value = 0;
+    progressText.textContent = '0%';
+}
+
+/**
+ * Update device info display
+ */
+function updateDeviceInfo(info: string): void {
+    deviceInfo.textContent = info;
+    deviceInfo.style.display = info ? 'block' : 'none';
+}
+
+/**
+ * Enable or disable UI elements based on state
+ */
+function updateUI(): void {
+    const isConnected = serialPort !== null && samba !== null;
+    const hasFirmware = firmwareData !== null;
+    
+    connectBtn.textContent = isConnected ? 'Disconnect' : 'Connect Device';
+    flashBtn.disabled = !isConnected || !hasFirmware;
+    fileInput.disabled = !isConnected;
+    
+    if (!isConnected) {
+        updateDeviceInfo('');
+        resetProgress();
+    }
+}
+
+/**
+ * Handle file selection
+ */
+async function handleFileSelect(event: Event): Promise<void> {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    
+    if (!file) {
+        firmwareData = null;
+        updateUI();
+        return;
+    }
+    
+    if (!file.name.endsWith('.bin')) {
+        logWarning('Selected file does not have .bin extension. Make sure it\'s a valid firmware file.');
+    }
+    
+    try {
+        const buffer = await file.arrayBuffer();
+        firmwareData = new Uint8Array(buffer);
+        log(`Loaded firmware: ${file.name} (${firmwareData.length} bytes)`);
+        updateUI();
+    } catch (error) {
+        logError(`Failed to read file: ${error}`);
+        firmwareData = null;
+        updateUI();
+    }
+}
+
+/**
+ * Connect to the device
+ */
+async function connect(): Promise<void> {
+    if (!checkBrowserSupport()) {
+        return;
+    }
+    
+    try {
+        log('Requesting serial port access...');
+        log('Select the bootloader port (enter bootloader mode by double-tapping reset)', 'warning');
+        
+        // Request a serial port from the user
+        serialPort = await navigator.serial.requestPort({
+            // Filter for common Arduino/Adafruit USB VID/PID combinations
+            filters: [
+                { usbVendorId: 0x239A }, // Adafruit
+                { usbVendorId: 0x2341 }, // Arduino
+                { usbVendorId: 0x1B4F }, // SparkFun
+                { usbVendorId: 0x03EB }, // Atmel
+            ]
+        });
+        
+        log('Serial port selected');
+        
+        // Create SamBA connection
+        samba = new SamBA(serialPort, {
+            debug: true,
+            logger: {
+                debug: (msg: unknown, ...args: unknown[]) => log(`DEBUG: ${msg} ${args.join(' ')}`),
+                log: (msg: unknown, ...args: unknown[]) => log(`${msg} ${args.join(' ')}`),
+                error: (msg: unknown, ...args: unknown[]) => logError(`${msg} ${args.join(' ')}`),
+            }
+        });
+        
+        log('Connecting to bootloader...');
+        await samba.connect();
+        logSuccess('Connected to SAM-BA bootloader');
+        
+        // Detect device
+        log('Detecting device...');
+        device = new Device(samba);
+        await device.create();
+        
+        const flash = device.flash;
+        if (flash) {
+            const sizeKB = Math.round(flash.totalSize / 1024);
+            const info = `Device: ${flash.numPages} pages × ${flash.pageSize} bytes = ${sizeKB}KB flash`;
+            updateDeviceInfo(info);
+            logSuccess(info);
+        }
+        
+        updateUI();
+        
+    } catch (error: unknown) {
+        if (error instanceof Error) {
+            if (error.name === 'NotFoundError') {
+                log('No port selected - cancelled by user');
+            } else if (error.message.includes('DeviceUnsupported')) {
+                logError('Device not supported. Make sure the device is in bootloader mode.');
+                logError('Try double-tapping the reset button.');
+            } else {
+                logError(`Connection failed: ${error.message}`);
+            }
+        } else {
+            logError(`Connection failed: ${error}`);
+        }
+        await disconnect();
+    }
+}
+
+/**
+ * Disconnect from the device
+ */
+async function disconnect(): Promise<void> {
+    try {
+        if (samba) {
+            try {
+                await samba.disconnect();
+            } catch (e) {
+                // Ignore disconnect errors
+            }
+        }
+        if (serialPort) {
+            try {
+                await serialPort.close();
+            } catch (e) {
+                // Ignore close errors
+            }
+        }
+    } finally {
+        serialPort = null;
+        samba = null;
+        device = null;
+        log('Disconnected');
+        updateUI();
+    }
+}
+
+/**
+ * Handle connect/disconnect button click
+ */
+async function handleConnectClick(): Promise<void> {
+    if (serialPort) {
+        await disconnect();
+    } else {
+        await connect();
+    }
+}
+
+/**
+ * Flash the firmware to the device
+ */
+async function flashFirmware(): Promise<void> {
+    if (!samba || !device || !firmwareData) {
+        logError('Not ready to flash. Connect device and select firmware first.');
+        return;
+    }
+    
+    const flash = device.flash;
+    if (!flash) {
+        logError('Flash not available');
+        return;
+    }
+    
+    // Disable buttons during flash
+    flashBtn.disabled = true;
+    connectBtn.disabled = true;
+    fileInput.disabled = true;
+    
+    try {
+        // Create flasher with observer for progress updates
+        const observer: FlasherObserver = {
+            onStatus: (message: string) => {
+                log(message.trim());
+            },
+            onProgress: (current: number, total: number) => {
+                updateProgress(current, total);
+            }
+        };
+        
+        const flasher = new Flasher(samba, flash, observer);
+        
+        // Erase flash
+        log('Erasing flash...');
+        await flasher.erase(0);
+        logSuccess('Flash erased');
+        
+        // Write firmware
+        log('Writing firmware...');
+        await flasher.write(firmwareData, 0);
+        logSuccess('Firmware written successfully!');
+        
+        // Reset device
+        log('Resetting device...');
+        await device.reset();
+        logSuccess('Device reset - new firmware should be running!');
+        
+        // The device will disconnect after reset
+        await disconnect();
+        
+    } catch (error) {
+        logError(`Flash failed: ${error}`);
+        
+        // Try to clean up
+        try {
+            await disconnect();
+        } catch (e) {
+            // Ignore cleanup errors
+        }
+    } finally {
+        updateUI();
+    }
+}
+
+/**
+ * Initialize the application
+ */
+function init(): void {
+    // Get UI elements
+    connectBtn = document.getElementById('connectBtn') as HTMLButtonElement;
+    flashBtn = document.getElementById('flashBtn') as HTMLButtonElement;
+    fileInput = document.getElementById('fileInput') as HTMLInputElement;
+    progressBar = document.getElementById('progressBar') as HTMLProgressElement;
+    progressText = document.getElementById('progressText') as HTMLSpanElement;
+    statusLog = document.getElementById('statusLog') as HTMLDivElement;
+    deviceInfo = document.getElementById('deviceInfo') as HTMLDivElement;
+    
+    // Set up event listeners
+    connectBtn.addEventListener('click', handleConnectClick);
+    flashBtn.addEventListener('click', flashFirmware);
+    fileInput.addEventListener('change', handleFileSelect);
+    
+    // Initial UI state
+    updateUI();
+    
+    // Check browser support
+    if (checkBrowserSupport()) {
+        log('Ready. Click "Connect Device" to begin.');
+        log('Make sure your device is in bootloader mode (double-tap reset button)', 'warning');
+    }
+}
+
+// Initialize when DOM is ready
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+} else {
+    init();
+}
+
+// Export for module usage
+export { init, connect, disconnect, flashFirmware };

--- a/src/example.ts
+++ b/src/example.ts
@@ -1,28 +1,39 @@
 /**
  * BOSSA Web Firmware Flasher Example
- * 
- * This module provides a simple web interface for flashing firmware
- * to ATSAMD21G-based devices (like Adafruit Feather M0) using the Web Serial API.
+ *
+ * One-click firmware flashing for ATSAMD21G-based devices using Web Serial API.
+ * The flow: Select firmware → Click Flash → Auto-reset to bootloader → Flash → Done
  */
 
 import { SamBA } from './samba';
-import { Device } from './device';
+import { Device, Family } from './device';
 import { Flasher, FlasherObserver } from './flasher';
+import { sleep } from './util';
+
+// Flash offset for SAMD devices with bootloader (bootloader uses first 8KB)
+// This is where the application code starts
+const BOOTLOADER_SIZE = 0x2000; // 8KB
+
+// USB Vendor IDs for common Arduino/Adafruit devices
+const USB_FILTERS = [
+    { usbVendorId: 0x239A }, // Adafruit
+    { usbVendorId: 0x2341 }, // Arduino
+    { usbVendorId: 0x1B4F }, // SparkFun
+    { usbVendorId: 0x03EB }, // Atmel
+];
 
 // UI Elements
-let connectBtn: HTMLButtonElement;
 let flashBtn: HTMLButtonElement;
 let fileInput: HTMLInputElement;
 let progressBar: HTMLProgressElement;
 let progressText: HTMLSpanElement;
 let statusLog: HTMLDivElement;
 let deviceInfo: HTMLDivElement;
+let fileInfo: HTMLDivElement;
 
 // State
-let serialPort: SerialPort | null = null;
-let samba: SamBA | null = null;
-let device: Device | null = null;
 let firmwareData: Uint8Array | null = null;
+let firmwareFileName: string = '';
 
 /**
  * Check if the browser supports Web Serial API
@@ -30,7 +41,7 @@ let firmwareData: Uint8Array | null = null;
 function checkBrowserSupport(): boolean {
     if (!('serial' in navigator)) {
         logError('Web Serial API is not supported in this browser.');
-        logError('Please use Chrome, Edge, or Opera.');
+        logError('Please use Chrome 89+, Edge 89+, or Opera 75+.');
         return false;
     }
     return true;
@@ -89,16 +100,15 @@ function updateDeviceInfo(info: string): void {
  * Enable or disable UI elements based on state
  */
 function updateUI(): void {
-    const isConnected = serialPort !== null && samba !== null;
     const hasFirmware = firmwareData !== null;
     
-    connectBtn.textContent = isConnected ? 'Disconnect' : 'Connect Device';
-    flashBtn.disabled = !isConnected || !hasFirmware;
-    fileInput.disabled = !isConnected;
+    flashBtn.disabled = !hasFirmware;
     
-    if (!isConnected) {
-        updateDeviceInfo('');
-        resetProgress();
+    if (hasFirmware) {
+        fileInfo.textContent = `${firmwareFileName} (${firmwareData!.length.toLocaleString()} bytes)`;
+        fileInfo.style.display = 'block';
+    } else {
+        fileInfo.style.display = 'none';
     }
 }
 
@@ -111,6 +121,7 @@ async function handleFileSelect(event: Event): Promise<void> {
     
     if (!file) {
         firmwareData = null;
+        firmwareFileName = '';
         updateUI();
         return;
     }
@@ -122,147 +133,224 @@ async function handleFileSelect(event: Event): Promise<void> {
     try {
         const buffer = await file.arrayBuffer();
         firmwareData = new Uint8Array(buffer);
-        log(`Loaded firmware: ${file.name} (${firmwareData.length} bytes)`);
+        firmwareFileName = file.name;
+        log(`Loaded firmware: ${file.name} (${firmwareData.length.toLocaleString()} bytes)`);
         updateUI();
     } catch (error) {
         logError(`Failed to read file: ${error}`);
         firmwareData = null;
+        firmwareFileName = '';
         updateUI();
     }
 }
 
 /**
- * Connect to the device
+ * Perform 1200 baud touch to reset device into bootloader mode
+ * This is the technique used by Arduino IDE to trigger bootloader
  */
-async function connect(): Promise<void> {
+async function resetToBootloader(port: SerialPort): Promise<void> {
+    log('Resetting device to bootloader mode...');
+    
+    try {
+        // Open at 1200 baud
+        await port.open({
+            baudRate: 1200,
+            dataBits: 8,
+            stopBits: 1,
+            parity: 'none',
+        });
+        
+        // Toggle DTR to trigger reset
+        // Setting DTR false then true triggers the bootloader on SAMD devices
+        await port.setSignals({ dataTerminalReady: false });
+        await sleep(100);
+        await port.setSignals({ dataTerminalReady: true });
+        await sleep(100);
+        await port.setSignals({ dataTerminalReady: false });
+        
+        // Close the port
+        await port.close();
+        
+        log('Reset signal sent, waiting for bootloader...');
+        
+        // Wait for the device to reset and enumerate as bootloader
+        // The bootloader takes about 1-2 seconds to appear
+        await sleep(2000);
+        
+        logSuccess('Device should now be in bootloader mode');
+        
+    } catch (error) {
+        // If we can't open the port, device might already be in bootloader mode
+        log('Could not perform reset - device may already be in bootloader mode');
+    }
+}
+
+/**
+ * Try to find the bootloader port from previously authorized ports
+ */
+async function findBootloaderPort(): Promise<SerialPort | null> {
+    try {
+        const ports = await navigator.serial.getPorts();
+        
+        // Look for a port that might be the bootloader
+        // After reset, a new port typically appears with the same vendor ID
+        for (const port of ports) {
+            const info = port.getInfo();
+            // Check if it matches our known vendor IDs
+            if (info.usbVendorId && USB_FILTERS.some(f => f.usbVendorId === info.usbVendorId)) {
+                log(`Found potential bootloader port: VID=${info.usbVendorId?.toString(16)}, PID=${info.usbProductId?.toString(16)}`);
+                return port;
+            }
+        }
+    } catch (e) {
+        // getPorts not available or failed
+    }
+    return null;
+}
+
+/**
+ * Main flash process - handles everything from port selection to flashing
+ */
+async function flashFirmware(): Promise<void> {
+    if (!firmwareData) {
+        logError('No firmware file selected.');
+        return;
+    }
+    
     if (!checkBrowserSupport()) {
         return;
     }
     
+    // Disable UI during flash
+    flashBtn.disabled = true;
+    fileInput.disabled = true;
+    resetProgress();
+    updateDeviceInfo('');
+    
+    let normalPort: SerialPort | null = null;
+    let bootloaderPort: SerialPort | null = null;
+    let samba: SamBA | null = null;
+    
     try {
-        log('Requesting serial port access...');
-        log('Select the bootloader port (enter bootloader mode by double-tapping reset)', 'warning');
+        // Step 1: Request the normal (sketch) port
+        log('Step 1: Select your device\'s serial port');
+        log('If already in bootloader mode, select the bootloader port', 'warning');
         
-        // Request a serial port from the user
-        serialPort = await navigator.serial.requestPort({
-            // Filter for common Arduino/Adafruit USB VID/PID combinations
-            filters: [
-                { usbVendorId: 0x239A }, // Adafruit
-                { usbVendorId: 0x2341 }, // Arduino
-                { usbVendorId: 0x1B4F }, // SparkFun
-                { usbVendorId: 0x03EB }, // Atmel
-            ]
+        normalPort = await navigator.serial.requestPort({
+            filters: USB_FILTERS
         });
         
         log('Serial port selected');
         
-        // Create SamBA connection
-        samba = new SamBA(serialPort, {
+        // Step 2: Try to reset to bootloader
+        // First check if it's already in bootloader mode by trying to connect
+        let isBootloaderMode = false;
+        
+        try {
+            log('Checking if device is already in bootloader mode...');
+            
+            // Try to open at bootloader baud rate and read version
+            await normalPort.open({
+                dataBits: 8,
+                stopBits: 1,
+                parity: 'none',
+                bufferSize: 63,
+                flowControl: 'hardware',
+                baudRate: 921600
+            });
+            
+            // Create a temporary SamBA to test
+            const testSamba = new SamBA(normalPort, { debug: false });
+            
+            // Try to set binary mode - if this works, we're in bootloader
+            // This will timeout quickly if not in bootloader mode
+            // We need to manually test since connect() will throw on failure
+            
+            await normalPort.close();
+            
+            // If we got here without error, it might be bootloader mode
+            // But we need to actually test the protocol
+            isBootloaderMode = false; // Assume not in bootloader, do reset
+            
+        } catch (e) {
+            // Port couldn't be opened or test failed - definitely not in bootloader mode
+            isBootloaderMode = false;
+        }
+        
+        if (!isBootloaderMode) {
+            // Perform 1200 baud touch reset
+            await resetToBootloader(normalPort);
+            
+            // After reset, we need to get a new port reference
+            // The original port is no longer valid
+            normalPort = null;
+            
+            // Step 3: Try to find the bootloader port automatically
+            log('Step 2: Looking for bootloader port...');
+            
+            bootloaderPort = await findBootloaderPort();
+            
+            if (!bootloaderPort) {
+                // Need user to select the bootloader port manually
+                log('Please select the bootloader port (it may have a different name now)', 'warning');
+                
+                bootloaderPort = await navigator.serial.requestPort({
+                    filters: USB_FILTERS
+                });
+            }
+        } else {
+            bootloaderPort = normalPort;
+        }
+        
+        // Step 3/4: Connect to bootloader
+        log('Step 3: Connecting to bootloader...');
+        
+        samba = new SamBA(bootloaderPort, {
             debug: true,
             logger: {
-                debug: (msg: unknown, ...args: unknown[]) => log(`DEBUG: ${msg} ${args.join(' ')}`),
+                debug: (msg: unknown, ...args: unknown[]) => console.log(`DEBUG: ${msg}`, ...args),
                 log: (msg: unknown, ...args: unknown[]) => log(`${msg} ${args.join(' ')}`),
                 error: (msg: unknown, ...args: unknown[]) => logError(`${msg} ${args.join(' ')}`),
             }
         });
         
-        log('Connecting to bootloader...');
         await samba.connect();
         logSuccess('Connected to SAM-BA bootloader');
         
         // Detect device
         log('Detecting device...');
-        device = new Device(samba);
+        const device = new Device(samba);
         await device.create();
         
         const flash = device.flash;
-        if (flash) {
-            const sizeKB = Math.round(flash.totalSize / 1024);
-            const info = `Device: ${flash.numPages} pages × ${flash.pageSize} bytes = ${sizeKB}KB flash`;
-            updateDeviceInfo(info);
-            logSuccess(info);
+        if (!flash) {
+            throw new Error('Flash not available on this device');
         }
         
-        updateUI();
+        const sizeKB = Math.round(flash.totalSize / 1024);
+        const info = `Device: ${flash.numPages} pages × ${flash.pageSize} bytes = ${sizeKB}KB flash`;
+        updateDeviceInfo(info);
+        logSuccess(info);
         
-    } catch (error: unknown) {
-        if (error instanceof Error) {
-            if (error.name === 'NotFoundError') {
-                log('No port selected - cancelled by user');
-            } else if (error.message.includes('DeviceUnsupported')) {
-                logError('Device not supported. Make sure the device is in bootloader mode.');
-                logError('Try double-tapping the reset button.');
-            } else {
-                logError(`Connection failed: ${error.message}`);
-            }
-        } else {
-            logError(`Connection failed: ${error}`);
+        // Determine flash offset based on device family
+        // SAMD21 and similar devices with bootloader need 0x2000 offset
+        let flashOffset = 0;
+        if (device.family === Family.FAMILY_SAMD21 ||
+            device.family === Family.FAMILY_SAMR21 ||
+            device.family === Family.FAMILY_SAML21) {
+            flashOffset = BOOTLOADER_SIZE;
+            log(`Using flash offset 0x${flashOffset.toString(16).toUpperCase()} (bootloader present)`);
         }
-        await disconnect();
-    }
-}
-
-/**
- * Disconnect from the device
- */
-async function disconnect(): Promise<void> {
-    try {
-        if (samba) {
-            try {
-                await samba.disconnect();
-            } catch (e) {
-                // Ignore disconnect errors
-            }
+        
+        // Check firmware size (accounting for bootloader area)
+        const availableFlash = flash.totalSize - flashOffset;
+        if (firmwareData.length > availableFlash) {
+            throw new Error(`Firmware (${firmwareData.length} bytes) is larger than available flash (${availableFlash} bytes after bootloader)`);
         }
-        if (serialPort) {
-            try {
-                await serialPort.close();
-            } catch (e) {
-                // Ignore close errors
-            }
-        }
-    } finally {
-        serialPort = null;
-        samba = null;
-        device = null;
-        log('Disconnected');
-        updateUI();
-    }
-}
-
-/**
- * Handle connect/disconnect button click
- */
-async function handleConnectClick(): Promise<void> {
-    if (serialPort) {
-        await disconnect();
-    } else {
-        await connect();
-    }
-}
-
-/**
- * Flash the firmware to the device
- */
-async function flashFirmware(): Promise<void> {
-    if (!samba || !device || !firmwareData) {
-        logError('Not ready to flash. Connect device and select firmware first.');
-        return;
-    }
-    
-    const flash = device.flash;
-    if (!flash) {
-        logError('Flash not available');
-        return;
-    }
-    
-    // Disable buttons during flash
-    flashBtn.disabled = true;
-    connectBtn.disabled = true;
-    fileInput.disabled = true;
-    
-    try {
-        // Create flasher with observer for progress updates
+        
+        // Step 4: Flash the firmware
+        log('Step 4: Flashing firmware...');
+        
         const observer: FlasherObserver = {
             onStatus: (message: string) => {
                 log(message.trim());
@@ -274,35 +362,71 @@ async function flashFirmware(): Promise<void> {
         
         const flasher = new Flasher(samba, flash, observer);
         
-        // Erase flash
-        log('Erasing flash...');
-        await flasher.erase(0);
+        // Erase flash (only the application area, not the bootloader)
+        log(`Erasing flash at offset 0x${flashOffset.toString(16).toUpperCase()}...`);
+        await flasher.erase(flashOffset);
         logSuccess('Flash erased');
         
-        // Write firmware
-        log('Writing firmware...');
-        await flasher.write(firmwareData, 0);
+        // Write firmware to the correct offset
+        log(`Writing firmware at offset 0x${flashOffset.toString(16).toUpperCase()}...`);
+        await flasher.write(firmwareData, flashOffset);
         logSuccess('Firmware written successfully!');
         
-        // Reset device
+        // Reset device to run new firmware
         log('Resetting device...');
         await device.reset();
-        logSuccess('Device reset - new firmware should be running!');
         
-        // The device will disconnect after reset
-        await disconnect();
-        
-    } catch (error) {
-        logError(`Flash failed: ${error}`);
-        
-        // Try to clean up
+        // Disconnect
         try {
-            await disconnect();
+            await samba.disconnect();
         } catch (e) {
-            // Ignore cleanup errors
+            // Reset may have already disconnected
         }
+        
+        try {
+            await bootloaderPort.close();
+        } catch (e) {
+            // May already be closed
+        }
+        
+        logSuccess('✅ Flash complete! Your device is now running the new firmware.');
+        updateProgress(100, 100);
+        
+    } catch (error: unknown) {
+        if (error instanceof Error) {
+            if (error.name === 'NotFoundError') {
+                log('No port selected - cancelled by user');
+            } else if (error.message.includes('DeviceUnsupported')) {
+                logError('Device not supported. Supported devices: ATSAMD21-based boards');
+            } else {
+                logError(`Flash failed: ${error.message}`);
+            }
+        } else {
+            logError(`Flash failed: ${error}`);
+        }
+        
+        // Cleanup on error
+        try {
+            if (samba) {
+                await samba.disconnect();
+            }
+        } catch (e) { /* ignore */ }
+        
+        try {
+            if (bootloaderPort) {
+                await bootloaderPort.close();
+            }
+        } catch (e) { /* ignore */ }
+        
+        try {
+            if (normalPort && normalPort !== bootloaderPort) {
+                await normalPort.close();
+            }
+        } catch (e) { /* ignore */ }
+        
     } finally {
-        updateUI();
+        flashBtn.disabled = false;
+        fileInput.disabled = false;
     }
 }
 
@@ -311,16 +435,15 @@ async function flashFirmware(): Promise<void> {
  */
 function init(): void {
     // Get UI elements
-    connectBtn = document.getElementById('connectBtn') as HTMLButtonElement;
     flashBtn = document.getElementById('flashBtn') as HTMLButtonElement;
     fileInput = document.getElementById('fileInput') as HTMLInputElement;
     progressBar = document.getElementById('progressBar') as HTMLProgressElement;
     progressText = document.getElementById('progressText') as HTMLSpanElement;
     statusLog = document.getElementById('statusLog') as HTMLDivElement;
     deviceInfo = document.getElementById('deviceInfo') as HTMLDivElement;
+    fileInfo = document.getElementById('fileInfo') as HTMLDivElement;
     
     // Set up event listeners
-    connectBtn.addEventListener('click', handleConnectClick);
     flashBtn.addEventListener('click', flashFirmware);
     fileInput.addEventListener('change', handleFileSelect);
     
@@ -329,8 +452,7 @@ function init(): void {
     
     // Check browser support
     if (checkBrowserSupport()) {
-        log('Ready. Click "Connect Device" to begin.');
-        log('Make sure your device is in bootloader mode (double-tap reset button)', 'warning');
+        log('Ready. Select a firmware file and click "Flash Firmware" to begin.');
     }
 }
 
@@ -342,4 +464,4 @@ if (document.readyState === 'loading') {
 }
 
 // Export for module usage
-export { init, connect, disconnect, flashFirmware };
+export { init, flashFirmware };

--- a/src/example.ts
+++ b/src/example.ts
@@ -1,7 +1,7 @@
 /**
  * BOSSA Web Firmware Flasher Example
  *
- * One-click firmware flashing for ATSAMD21G-based devices using Web Serial API.
+ * Easy firmware flashing for ATSAMD21G-based devices using Web Serial API.
  * The flow: Select firmware → Click Flash → Auto-reset to bootloader → Flash → Done
  */
 
@@ -14,12 +14,12 @@ import { sleep } from './util';
 // This is where the application code starts
 const BOOTLOADER_SIZE = 0x2000; // 8KB
 
-// USB Vendor IDs for common Arduino/Adafruit devices
+// USB Vendor IDs for common Arduino/Adafruit devices. These VIDs are specific for bootloader mode.
 const USB_FILTERS = [
     { usbVendorId: 0x239A }, // Adafruit
     { usbVendorId: 0x2341 }, // Arduino
     { usbVendorId: 0x1B4F }, // SparkFun
-    { usbVendorId: 0x03EB }, // Atmel
+    { usbVendorId: 0x03EB }, // Atmel/Microchip
 ];
 
 // UI Elements
@@ -41,7 +41,7 @@ let firmwareFileName: string = '';
 function checkBrowserSupport(): boolean {
     if (!('serial' in navigator)) {
         logError('Web Serial API is not supported in this browser.');
-        logError('Please use Chrome 89+, Edge 89+, or Opera 75+.');
+        logError('Please use a Chromium-based browser (Chrome 89+, Edge 89+, Opera 75+, Brave1.22+, etc.');
         return false;
     }
     return true;
@@ -146,7 +146,7 @@ async function handleFileSelect(event: Event): Promise<void> {
 
 /**
  * Perform 1200 baud touch to reset device into bootloader mode
- * This is the technique used by Arduino IDE to trigger bootloader
+ * This is the technique used by the Arduino IDE to enter the bootloader
  */
 async function resetToBootloader(port: SerialPort): Promise<void> {
     log('Resetting device to bootloader mode...');

--- a/src/samba.ts
+++ b/src/samba.ts
@@ -128,7 +128,7 @@ export class SamBA {
 
     let num = parseInt(value, 16);
 
-    if (num == NaN) {
+    if (Number.isNaN(num)) {
       throw new SamBAError('Invalid checksum returned');
     }
 
@@ -257,7 +257,7 @@ export class SamBA {
       let value = (result[3] << 24 | result[2] << 16 | result[1] << 8 | result[0] << 0);
 
       if (this.options.debug)
-        this.options.logger.debug('readByte(addr=0x', this.hex(addr),')=0x',this.hex(value,8));
+        this.options.logger.debug('readWord(addr=0x', this.hex(addr),')=0x',this.hex(value,8));
 
       return value;
     }
@@ -511,9 +511,9 @@ export class SamBA {
         await sleep(10);
       }
 
-      if (reply.length > 1 && (reply[reply.length - 1] == 0x0)) {
-        break;
-      }
+      // if (reply.length > 1 && (reply[reply.length - 1] == 0x0)) {
+      //   break;
+      // }
 
       if (responseSize && reply.length == responseSize) {
         break;


### PR DESCRIPTION
## Description
This adds a simple web UI which demonstrates using bossa-web to flash a pre-compiled firmware binary to a USB-connected ATSAMD21-based development board. The example includes features such as:
- **One-click flashing** - Just select your firmware and click Flash
- **Progress tracking** - Real-time status logs and progress bar built into the UI.
- **Auto-reset** - Uses 1200 baud-touch technique to automatically enter bootloader mode (like the Arduino IDE).
- **Automatic Port Detection** - Attempts to automatically detect known USB vendor IDs while in bootloader mode to minimize necessary user interaction.

I tested this and confirmed that it can successfully flash firmware to an **Adafruit Feather M0** via Brave Browser v1.84 and Chromium v142 on Mac OS 13.7. Wider compatibility is expected, but has not yet been tested.

## Usage
### 1. Build the Project

```bash
# Install dependencies
npm install

# Build the library
npm run build

# Build the example
npm run build:example
```

### 2. Serve the Example

```bash
# Serve locally (opens http://localhost:3000)
npm run serve
```

### 3. Flash Your Device

1. **Select Firmware** - Click "Select Firmware (.bin)" and choose your compiled .bin file
2. **Click "Flash Firmware"** - The tool will automatically:
   - Ask you to select your device's serial port
   - Reset the device into bootloader mode
   - Connect to the bootloader
   - Erase and write the firmware
   - Reset the device to run the new code